### PR TITLE
flaky bug fixed

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MultiDocumentStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MultiDocumentStoreTest.java
@@ -416,7 +416,9 @@ public class MultiDocumentStoreTest extends AbstractMultiDocumentStoreTest {
                 ds.createOrUpdate(NODES, ops);
 
                 assertTrue(logCustomizer.getLogs().size() == 1);
-                assertTrue(logCustomizer.getLogs().get(0).contains("failure for [" + modifiedRow + ", " + deletedRow + "]"));
+                Boolean compareOne = logCustomizer.getLogs().get(0).contains("failure for [" + modifiedRow + ", " + deletedRow + "]");
+                Boolean compareTwo = logCustomizer.getLogs().get(0).contains("failure for [" + deletedRow + ", " + modifiedRow + "]");
+                assertTrue(compareOne || compareTwo);
                 // System.out.println(logCustomizer.getLogs());
                 assertTrue(logCustomizerJDBC.getLogs().size() == 1);
                 assertTrue(logCustomizerJDBC.getLogs().get(0).contains("0 (for " + modifiedRow + " (1)"));


### PR DESCRIPTION

##### Test Cases working on `MultiDocumentStoreTest.testTraceLoggingForBulkUpdates[RDBFixture: RDB-H2(file)]`
**Github Link**: https://github.com/KellyKailid/jackrabbit-oak/tree/fix-flaky
**Function**:  `org.apache.jackrabbit.oak.plugins.document.MultiDocumentStoreTest.testTraceLoggingForBulkUpdates[RDBFixture: RDB-H2(file)]`

##### Problems
  - `assertTrue` check fails => reasons: because the logCustomizer does not contain the desire string. This happened at file `MultiDocumentStoreTest.java` line 419.
  - by digging into the class `logCustomizer`, the main data structure is `List`, since `List` usually preserve the order, I think problem may somewhere else,
  - by reading the `logCustomizer.java` I noticed that `logCustomizer` has use another data structure called `Appender<ILoggingEvent> customLogger` which I believe it dealing with adding some customized logging into variable 'log', and by searching `stackoverflow` it shows that 'Appender<ILoggingEvent>' works synchronously. Hence, this might causing the flaky problem.

##### Solutions
- After I found the problem, I think the solution is relatively easy. Since there is no internal logic flaky error. I think all I need to do is check all possible that will occur in the test. Thus, I create two variable called `compareOne` and `compareTwo` and change has been list below. 
```
  Boolean compareOne = logCustomizer.getLogs().get(0).contains("failure for [" + modifiedRow + ", " + deletedRow + "]");
  Boolean compareTwo = logCustomizer.getLogs().get(0).contains("failure for [" + deletedRow + ", " + modifiedRow + "]");
  assertTrue(compareOne || compareTwo);
```